### PR TITLE
fix: add appropriate defaultText entries to options

### DIFF
--- a/modules/nixos/bluetooth.nix
+++ b/modules/nixos/bluetooth.nix
@@ -4,6 +4,7 @@
     lib.mkEnableOption "Enable the Facter bluetooth module"
     // {
       default = builtins.length (config.facter.report.hardware.bluetooth or [ ]) > 0;
+      defaultText = "hardware dependent";
     };
 
   config.hardware.bluetooth.enable = lib.mkIf config.facter.detected.bluetooth.enable (

--- a/modules/nixos/disk.nix
+++ b/modules/nixos/disk.nix
@@ -16,6 +16,7 @@ in
         ++ (report.hardware.storage_controller or [ ])
       )
     );
+    defaultText = "hardware dependent";
     description = ''
       List of kernel modules that are needed to access the disk.
     '';

--- a/modules/nixos/facter.nix
+++ b/modules/nixos/facter.nix
@@ -25,6 +25,7 @@
           { }
         else
           builtins.fromJSON (builtins.readFile config.facter.reportPath);
+      defaultText = "A JSON import from config.facter.reportPath (if not null), {} otherwise.";
       description = "An import for the reportPath.";
     };
 

--- a/modules/nixos/graphics/amd.nix
+++ b/modules/nixos/graphics/amd.nix
@@ -9,6 +9,7 @@ in
       default = builtins.elem "amdgpu" (
         facterLib.collectDrivers (config.facter.report.hardware.graphics_card or [ ])
       );
+      defaultText = "hardware dependent";
     };
   };
   config = lib.mkIf cfg.enable {

--- a/modules/nixos/graphics/default.nix
+++ b/modules/nixos/graphics/default.nix
@@ -10,6 +10,7 @@ in
   options.facter.detected = {
     graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {
       default = builtins.length (config.facter.report.hardware.monitor or [ ]) > 0;
+      defaultText = "hardware dependent";
     };
     boot.graphics.kernelModules = lib.mkOption {
       type = lib.types.listOf lib.types.str;
@@ -18,6 +19,7 @@ in
       default = lib.remove "nouveau" (
         facterLib.stringSet (facterLib.collectDrivers (config.facter.report.hardware.graphics_card or [ ]))
       );
+      defaultText = "hardware dependent";
       description = ''
         List of kernel modules to load at boot for the graphics card.
       '';

--- a/modules/nixos/keyboard.nix
+++ b/modules/nixos/keyboard.nix
@@ -8,6 +8,7 @@ in
   options.facter.detected.boot.keyboard.kernelModules = lib.mkOption {
     type = lib.types.listOf lib.types.str;
     default = facterLib.stringSet (facterLib.collectDrivers (report.hardware.usb_controller or [ ]));
+    defaultText = "hardware dependent";
     example = [ "usbhid" ];
     description = ''
       List of kernel modules to include in the initrd to support the keyboard.

--- a/modules/nixos/networking/default.nix
+++ b/modules/nixos/networking/default.nix
@@ -8,6 +8,7 @@
 
   options.facter.detected.dhcp.enable = lib.mkEnableOption "Facter dhcp module" // {
     default = builtins.length config.facter.report.hardware.network_interface or [ ] > 0;
+    defaultText = "hardware dependent";
   };
   config = lib.mkIf config.facter.detected.dhcp.enable {
     networking.useDHCP = lib.mkDefault true;

--- a/modules/nixos/networking/initrd.nix
+++ b/modules/nixos/networking/initrd.nix
@@ -10,6 +10,7 @@ in
     default = facterLib.stringSet (
       facterLib.collectDrivers (report.hardware.network_controller or [ ])
     );
+    defaultText = "hardware dependent";
     description = ''
       List of kernel modules to include in the initrd to support networking.
     '';


### PR DESCRIPTION
Avoids issues with docs generation when referring to config from within an option's `default`.