### PR TITLE
facter: allow partially overriding fields in `facter.report`

### DIFF
--- a/modules/nixos/facter.nix
+++ b/modules/nixos/facter.nix
@@ -19,7 +19,7 @@
 
   options.facter = with lib; {
     report = mkOption {
-      type = types.raw;
+      type = types.attrsOf types.anything;
       default =
         if config.facter.reportPath == null then
           { }


### PR DESCRIPTION
This is useful if I'm constructing a VM of my configuration and I want to ensure `facter.detected.virtualisation` is correct:

    {
      virtualisation.vmVariant = { lib, ... }: {
        facter.report = lib.mkOptionDefault {
          virtualisation = lib.mkForce "qemu";
        };
      };
    }