### PR TITLE
fix: Keep networkd disabled when using NetworkManager

### DIFF
--- a/modules/nixos/networking/default.nix
+++ b/modules/nixos/networking/default.nix
@@ -12,6 +12,6 @@
   };
   config = lib.mkIf config.facter.detected.dhcp.enable {
     networking.useDHCP = lib.mkDefault true;
-    networking.useNetworkd = lib.mkDefault true;
+    networking.useNetworkd = lib.mkDefault (!config.networking.networkmanager.enable);
   };
 }


### PR DESCRIPTION
In most desktop environments, NetworkManager is utilized to manage network settings. However, the current networking module do not take this into account, leading to the automatic activation of systemd-networkd. This results in failures during `nixos-rebuild switch` and `nixos-rebuild test`, as the systemd-networkd-wait-online.service cannot detect an internet connection. This pull request addresses the issue (#62) by verifying whether NetworkManager is enabled before activating networkd.

```
the following new units were started: systemd-networkd-persistent-storage.service, systemd-networkd.service, systemd-networkd.socket, systemd-resolved.service
warning: the following units failed: systemd-networkd-wait-online.service
× systemd-networkd-wait-online.service - Wait for Network to be Configured
     Loaded: loaded (/etc/systemd/system/systemd-networkd-wait-online.service; enabled; preset: ignored)
    Drop-In: /nix/store/biaayqb2jz7i98vzwvnv03zpxbqmb158-system-units/systemd-networkd-wait-online.service.d
             └─overrides.conf
     Active: failed (Result: exit-code) since Sat 2025-08-16 17:49:48 CEST; 274ms ago
 Invocation: 39fd49f7ff1841bd870fddad8bedd41d
       Docs: man:systemd-networkd-wait-online.service(8)
    Process: 30009 ExecStart=/nix/store/wq3ivni0plh7g8xl3my8qr9llh4dy7q4-systemd-257.6/lib/systemd/systemd-networkd-wait-online --timeout=120 (code=exited, status=1/FAILURE)
   Main PID: 30009 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
         IO: 64K read, 0B written
   Mem peak: 2.2M
        CPU: 32ms

Aug 16 17:47:48 nixos systemd[1]: Starting Wait for Network to be Configured...
Aug 16 17:49:48 nixos systemd-networkd-wait-online[30009]: Timeout occurred while waiting for network connectivity.
Aug 16 17:49:48 nixos systemd[1]: systemd-networkd-wait-online.service: Main process exited, code=exited, status=1/FAILURE
Aug 16 17:49:48 nixos systemd[1]: systemd-networkd-wait-online.service: Failed with result 'exit-code'.
Aug 16 17:49:48 nixos systemd[1]: Failed to start Wait for Network to be Configured.
Command 'systemd-run -E LOCALE_ARCHIVE -E NIXOS_INSTALL_BOOTLOADER --collect --no-ask-password --pipe --quiet --service-type=exec --unit=nixos-rebuild-switch-to-configuration /nix/store/4k1frxrlfh6k61py9k30xh02k7km54kz-nixos-system-nixos-25.11.20250814.fbcf476/bin/switch-to-configuration switch' returned non-zero exit status 4.
```