### PR TITLE
networkd is still useful to have i.e. when using the wireguard module

### DIFF
--- a/modules/nixos/networking/default.nix
+++ b/modules/nixos/networking/default.nix
@@ -11,6 +11,10 @@
   };
   config = lib.mkIf config.facter.detected.dhcp.enable {
     networking.useDHCP = lib.mkDefault true;
-    networking.useNetworkd = lib.mkDefault (!config.networking.networkmanager.enable);
+    # if we have NetworkManager and also wait-online target enabled,
+    # we should not use systemd-networkd.
+    networking.useNetworkd = lib.mkDefault (
+      !(config.networking.networkmanager.enable || config.systemd.network.wait-online.enable)
+    );
   };
 }


### PR DESCRIPTION
the current mkDefault can easily conflict with other projects like clan or srvos where we also use `lib.mkDefault`.
This change preserves the original intent in https://github.com/nix-community/nixos-facter-modules/pull/79 without loosing useNetworkd for other tasks.
cc @hfxbse