### PR TITLE
replace useNetworkd with nixos-generate-config does

### DIFF
--- a/modules/nixos/networking/default.nix
+++ b/modules/nixos/networking/default.nix
@@ -1,19 +1,69 @@
 { config, lib, ... }:
+let
+  # Filter network interfaces from facter report to only those suitable for DHCP
+  physicalInterfaces = lib.filter (
+    iface:
+    # Only include network interfaces suitable for DHCP:
+    # - Ethernet (most common)
+    # - WLAN (WiFi)
+    # - USB-Link (USB network adapters, tethering)
+    # - Network Interface (generic/unknown type)
+    # This implicitly excludes: Loopback, mainframe-specific interfaces (CTC, IUCV, HSI, ESCON)
+    # See: https://github.com/numtide/hwinfo/blob/ea251a7/src/ids/src/class#L817-L874
+    let
+      validTypes = [
+        "Ethernet"
+        "WLAN"
+        "USB-Link"
+        "Network Interface"
+      ];
+    in
+    lib.elem (iface.sub_class.name or "") validTypes
+  ) (config.facter.report.hardware.network_interface or [ ]);
+
+  # Extract interface names from unix_device_names
+  detectedInterfaceNames = lib.concatMap (iface: iface.unix_device_names or [ ]) physicalInterfaces;
+
+  # Get the interface names from the configuration (which defaults to detectedInterfaceNames)
+  interfaceNames = config.facter.detected.dhcp.interfaces;
+
+  # Generate per-interface DHCP config
+  perInterfaceConfig = lib.listToAttrs (
+    lib.map (name: {
+      inherit name;
+      value = {
+        useDHCP = lib.mkDefault true;
+      };
+    }) interfaceNames
+  );
+in
 {
   imports = [
     ./initrd.nix
     ./intel.nix
   ];
 
-  options.facter.detected.dhcp.enable = lib.mkEnableOption "Facter dhcp module" // {
-    default = builtins.length config.facter.report.hardware.network_interface or [ ] > 0;
-    defaultText = "hardware dependent";
+  options.facter.detected.dhcp = {
+    enable = lib.mkEnableOption "Facter dhcp module" // {
+      default = builtins.length config.facter.report.hardware.network_interface or [ ] > 0;
+      defaultText = "hardware dependent";
+    };
+
+    interfaces = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = detectedInterfaceNames;
+      defaultText = lib.literalExpression "automatically detected from facter report";
+      description = "List of network interface names to configure with DHCP. Defaults to auto-detected physical interfaces.";
+      example = [
+        "eth0"
+        "wlan0"
+      ];
+    };
   };
   config = lib.mkIf config.facter.detected.dhcp.enable {
     networking.useDHCP = lib.mkDefault true;
-    # Disable networkd when both NetworkManager and wait-online are enabled
-    networking.useNetworkd = lib.mkDefault (
-      !(config.networking.networkmanager.enable && config.systemd.network.wait-online.enable)
-    );
+
+    # Per-interface DHCP configuration
+    networking.interfaces = perInterfaceConfig;
   };
 }


### PR DESCRIPTION
There is the caveat that interface names could potentially differ between an installer and the installed system.

Overall I would like to burn scripted networking with fire, but this is not the place and time to do it.

Ideally we would also use mac addresses to make sure sure interface names are stable, but don't have this information in facter report for privacy reasons.


Fix for https://github.com/nix-community/nixos-facter-modules/issues/85